### PR TITLE
Diff arguments for each plugin invoke

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -2,6 +2,18 @@ var _plugins = [];
 var _byName = {};
 var _cache = {};
 
+// Only support debug mode on browser and node, not web workers.
+var isBrowser =
+  typeof window !== "undefined" && typeof window.document !== "undefined";
+
+var isNode =
+  typeof process !== "undefined" &&
+  process.versions != null &&
+  process.versions.node != null;
+
+var isDebug = (isBrowser && document.location.search.includes('JS_PLUGIN_DEBUG'))
+    || (isNode && process.env && process.env.JS_PLUGIN_DEBUG);
+
 function _isFunc(o) {
   return !!(o.constructor && o.call && o.apply);
 }
@@ -106,12 +118,12 @@ module.exports = {
     var arr = prop.split('.');
     arr.pop();
     var obj = arr.join('.');
-    var isDebug = DEBUG_INVOKE;
+    
     return this.getPlugins(prop).map(function(p) {
       var method = _get(p, prop);
       if (!_isFunc(method) || noCall) return method;
       try {
-        isDebug && console.debug('Before', p.name, obj, args);
+        isDebug && console.log('Before', p.name, prop, args);
         return method.apply(_get(p, obj), args);
       } catch (err) {
         // When a plugin failed, doesn't break the app
@@ -119,7 +131,7 @@ module.exports = {
         if (throws) throw err;
         else console.log(err);
       } finally {
-        isDebug && console.debug('After', p.name, obj, args);
+        isDebug && console.log('After ', p.name, prop, args);
       }
       return null;
     });

--- a/plugin.js
+++ b/plugin.js
@@ -106,16 +106,20 @@ module.exports = {
     var arr = prop.split('.');
     arr.pop();
     var obj = arr.join('.');
+    var isDebug = DEBUG_INVOKE;
     return this.getPlugins(prop).map(function(p) {
       var method = _get(p, prop);
       if (!_isFunc(method) || noCall) return method;
       try {
+        isDebug && console.debug('Before', p.name, obj, args);
         return method.apply(_get(p, obj), args);
       } catch (err) {
         // When a plugin failed, doesn't break the app
         console.log('Failed to invoke plugin: ' + p.name + '!' + prop);
         if (throws) throw err;
         else console.log(err);
+      } finally {
+        isDebug && console.debug('After', p.name, obj, args);
       }
       return null;
     });


### PR DESCRIPTION
Sometimes, one plugin may accidentally changed the arguments unintentionally. And it's hard to locate the plugin, when there are many of them. So now we can use a flag to enable debug of arguments, between each plugin invoke.